### PR TITLE
Add component to disable validation updates

### DIFF
--- a/.changeset/plenty-chefs-allow.md
+++ b/.changeset/plenty-chefs-allow.md
@@ -1,0 +1,5 @@
+---
+"@radiantguild/form-contexts": minor
+---
+
+Added a `<NoValidationUpdates>` component that disables any validation update calls in its children. See `useValidationUpdate`’s docs for more info.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@changesets/changelog-github': ^0.4.4
@@ -25,11 +25,11 @@ devDependencies:
   '@changesets/cli': 2.22.0
   '@size-limit/preset-small-lib': 7.0.8_size-limit@7.0.8
   '@types/react': 17.0.43
-  '@typescript-eslint/eslint-plugin': 5.18.0_a07dca3bdfc4bfa60f4dda0c1f9e3287
-  '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.6.3
+  '@typescript-eslint/eslint-plugin': 5.18.0_ub64uo67ys72md2n3igb7hrsq4
+  '@typescript-eslint/parser': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
   eslint: 8.12.0
-  eslint-import-resolver-typescript: 2.7.1_6727bad621c6c338589cdfead936b843
-  eslint-plugin-import: 2.26.0_eslint@8.12.0
+  eslint-import-resolver-typescript: 2.7.1_m4t3vvrby3btqwe437vnsnvyim
+  eslint-plugin-import: 2.26.0_v7553xuiooqtxoizodjl66bgmm
   prettier: 2.6.2
   react: 18.0.0
   size-limit: 7.0.8
@@ -425,7 +425,7 @@ packages:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.18.0_a07dca3bdfc4bfa60f4dda0c1f9e3287:
+  /@typescript-eslint/eslint-plugin/5.18.0_ub64uo67ys72md2n3igb7hrsq4:
     resolution: {integrity: sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -436,10 +436,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.6.3
+      '@typescript-eslint/parser': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
       '@typescript-eslint/scope-manager': 5.18.0
-      '@typescript-eslint/type-utils': 5.18.0_eslint@8.12.0+typescript@4.6.3
-      '@typescript-eslint/utils': 5.18.0_eslint@8.12.0+typescript@4.6.3
+      '@typescript-eslint/type-utils': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
+      '@typescript-eslint/utils': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
       debug: 4.3.4
       eslint: 8.12.0
       functional-red-black-tree: 1.0.1
@@ -452,7 +452,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.18.0_eslint@8.12.0+typescript@4.6.3:
+  /@typescript-eslint/parser/5.18.0_thk3xo4exzjr5rl6cnexo7v6re:
     resolution: {integrity: sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -480,7 +480,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.18.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.18.0_eslint@8.12.0+typescript@4.6.3:
+  /@typescript-eslint/type-utils/5.18.0_thk3xo4exzjr5rl6cnexo7v6re:
     resolution: {integrity: sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -490,7 +490,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.18.0_eslint@8.12.0+typescript@4.6.3
+      '@typescript-eslint/utils': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
       debug: 4.3.4
       eslint: 8.12.0
       tsutils: 3.21.0_typescript@4.6.3
@@ -525,7 +525,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.18.0_eslint@8.12.0+typescript@4.6.3:
+  /@typescript-eslint/utils/5.18.0_thk3xo4exzjr5rl6cnexo7v6re:
     resolution: {integrity: sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -876,12 +876,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -1234,9 +1244,11 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/2.7.1_6727bad621c6c338589cdfead936b843:
+  /eslint-import-resolver-typescript/2.7.1_m4t3vvrby3btqwe437vnsnvyim:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -1245,7 +1257,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 8.12.0
-      eslint-plugin-import: 2.26.0_eslint@8.12.0
+      eslint-plugin-import: 2.26.0_v7553xuiooqtxoizodjl66bgmm
       glob: 7.2.0
       is-glob: 4.0.3
       resolve: 1.22.0
@@ -1254,27 +1266,51 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_egppdyvlhpj37iq4gwrexve7ny:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 2.7.1_m4t3vvrby3btqwe437vnsnvyim
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_eslint@8.12.0:
+  /eslint-plugin-import/2.26.0_v7553xuiooqtxoizodjl66bgmm:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.18.0_thk3xo4exzjr5rl6cnexo7v6re
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.12.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_egppdyvlhpj37iq4gwrexve7ny
       has: 1.0.3
       is-core-module: 2.8.1
       is-glob: 4.0.3
@@ -1282,6 +1318,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-scope/5.1.1:

--- a/src/contexts/NoValidationUpdateContext.ts
+++ b/src/contexts/NoValidationUpdateContext.ts
@@ -1,0 +1,3 @@
+import {createContext} from "react";
+
+export const NoValidationUpdateContext = createContext<boolean>(false);

--- a/src/hooks/useInputValidity.ts
+++ b/src/hooks/useInputValidity.ts
@@ -1,5 +1,6 @@
 import {useContext, useEffect} from "react";
 import {FormContext} from "~/contexts/FormContext";
+import {NoValidationUpdateContext} from "~/contexts/NoValidationUpdateContext";
 
 /**
  * Notifies the wrapping form about the validity of this input
@@ -9,11 +10,12 @@ import {FormContext} from "~/contexts/FormContext";
  */
 export default function useInputValidity(isValid: boolean) {
     const context = useContext(FormContext);
+    const disabled = useContext(NoValidationUpdateContext);
 
     useEffect(() => {
-        if (!context || isValid) return;
+        if (!context || isValid || disabled) return;
 
         context.addInvalid();
         return () => context.removeInvalid();
-    }, [context, isValid]);
+    }, [context, disabled, isValid]);
 }

--- a/src/hooks/useValidationUpdate.ts
+++ b/src/hooks/useValidationUpdate.ts
@@ -1,18 +1,25 @@
 import {ValidateResult} from "@radiantguild/yoogi";
 import {useContext, useEffect} from "react";
 import {ValidationSetterContext} from "~/contexts/ValidationSetterContext";
+import {NoValidationUpdateContext} from "~/contexts/NoValidationUpdateContext";
 
 /**
- * Sets the validation result of this input so that `useValidation` can read it
+ * Sets the validation result of this input so that `useValidation` can read it.
+ *
+ * If a composite form field includes sub-fields with `useValidationUpdate` (or `useInputState`),
+ * the composite form field should wrap those elements in `<NoValidationUpdates>` to prevent clashing updates.
  *
  * @see ValidationProvider
  * @see useValidation
+ * @see NoValidationUpdates
  */
 export default function useValidationUpdate(result: ValidateResult | null): void {
     const setValidateResult = useContext(ValidationSetterContext);
+    const disabled = useContext(NoValidationUpdateContext);
 
     useEffect(() => {
+        if (disabled) return;
         setValidateResult?.update(result);
-    }, [setValidateResult, result]);
+    }, [disabled, setValidateResult, result]);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,5 @@ export {InlineGroup} from "~/providers/InlineGroup";
 export type {InlineGroupProps} from "~/providers/InlineGroup";
 export {ValidationProvider} from "~/providers/ValidationProvider";
 export type {ValidationProviderProps} from "~/providers/ValidationProvider";
+export {NoValidationUpdates} from "~/providers/NoValidationUpdates";
+export type {NoValidationUpdatesProps} from "~/providers/NoValidationUpdates";

--- a/src/providers/NoValidationUpdates.ts
+++ b/src/providers/NoValidationUpdates.ts
@@ -1,0 +1,19 @@
+import {createElement, ReactNode} from "react";
+import {NoValidationUpdateContext} from "~/contexts/NoValidationUpdateContext";
+
+export interface NoValidationUpdatesProps {
+    children: ReactNode;
+}
+
+/**
+ * Nullifies any `useValidationUpdate` calls by child nodes
+ *
+ * @see useValidationUpdate
+ */
+export function NoValidationUpdates({children}: NoValidationUpdatesProps) {
+    return createElement(
+        NoValidationUpdateContext.Provider,
+        {value: true},
+        children
+    )
+}


### PR DESCRIPTION
This PR adds a new component, `<NoValidationUpdates>`. Any calls to `useValidationUpdate` or `useInputValidity` in children of the component are ignored.

The use-case of this component is for composite form fields that have their own validity, independent of the validity of any of the child fields. The expected behaviour here is that the `useValidityUpdate` call in the composite form field overwrites that of the children, but in reality it doesn't. So, this component acts as a way to turn off the child fields’ validation to prevent any weirdness.